### PR TITLE
Fixing link + adding an example for those using the 'binder' folder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ packages:
 #!/bin/bash
 quilt install
 ```
-If your are adopting the `binder` folder pattern and putting your `quilt.yml` inside of it, your `postBuild` file should look like this:
+If you are adopting the `binder` folder pattern for your repo2docker configuration files, and including `quilt.yml`, your postBuild file should look like this:
 
 ```bash
 #!/bin/bash
 quilt install @./binder/quilt.yml
 ```
-
+More info about how to install data packages via the `quilt install` command is available [here](https://docs.quiltdata.com/api/api-cli#quilt-install-file-quilt-yml).
     
 4. Now you can access the package data in your Jupyter notebooks:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Data packages are versioned, immutable snapshots of data. Data packages may cont
 
 1. Add `quilt` to `requirements.txt`
 
-2. Specify data package dependencies in `quilt.yml` ([docs](https://docs.quiltdata.com/cli.html)). For example:
+2. Specify data package dependencies in `quilt.yml` ([docs](https://docs.quiltdata.com/api/api-cli)). For example:
 
 ```
 packages:
@@ -23,12 +23,19 @@ packages:
 
 3. Include the following lines at the top of `postBuild`. (`postBuild` should be executable: `chmod +x postBuild` on UNIX, `git update-index --chmod=+x postBuild` for Windows).
 
-``` bash
+```bash
 #!/bin/bash
 quilt install
 ```
+If your are adopting the `binder` folder pattern and putting your `quilt.yml` inside of it, your `postBuild` file should look like this:
+
+```bash
+#!/bin/bash
+quilt install @./binder/quilt.yml
+```
+
     
-Now you can access the package data in your Jupyter notebooks:
+4. Now you can access the package data in your Jupyter notebooks:
 
 ```
 In [1]: from quilt.data.akarve import sales


### PR DESCRIPTION
I've noticed that many projects are putting all the repo2docker configuration files (postBuild, apt.txt etc.) within the `binder` folder. Naturally, some people (me included) tried to put the suggested quilt.yml file within the binder folder too, causing an error during image building. 
I'm suggesting an additional comment on the _readme_ to indicate that the filepath should be pointed, preceded  by an `@`, in the postBuild file.

I also fixed the link to the CLI docs on Quilt's website.
